### PR TITLE
Fix that the app of recent new versions cannot connect through proxy on Windows.

### DIFF
--- a/lib/common/service/ehconfig_service.dart
+++ b/lib/common/service/ehconfig_service.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:enum_to_string/enum_to_string.dart';
 import 'package:fehviewer/common/controller/webdav_controller.dart';
 import 'package:fehviewer/common/service/base_service.dart';
@@ -291,8 +293,12 @@ class EhConfigService extends ProfileService {
     super.onInit();
 
     // nativeHttpClientAdapter
-    nativeHttpClientAdapter =
-        ehConfig.nativeHttpClientAdapter ?? nativeHttpClientAdapter;
+    if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
+      nativeHttpClientAdapter =
+          ehConfig.nativeHttpClientAdapter ?? nativeHttpClientAdapter;
+    } else {
+      nativeHttpClientAdapter = false;
+    }
     everProfile<bool>(_nativeHttpClientAdapter, (val) {
       ehConfig = ehConfig.copyWith(nativeHttpClientAdapter: val);
     });


### PR DESCRIPTION
Initialize nativeHttpClientAdapter to false on unsupported platforms.
Current state:
<img width="600" alt="image" src="https://github.com/honjow/FEhViewer/assets/17916222/9a7fdea0-19ff-4519-b140-6dc8f04d7b81">
Known workarounds:
Use VPN or network stack hijacking tools to make the traffic of the apps redirect to the site.