### PR TITLE
Parse showKey before precache

### DIFF
--- a/lib/pages/image_view/controller/view_controller.dart
+++ b/lib/pages/image_view/controller/view_controller.dart
@@ -568,6 +568,19 @@ class ViewExtController extends GetxController {
         await _galleryPageController?.loadImagesForSer(itemSer);
       }
 
+      var needShowKey =
+          vState.pageState?.galleryProvider?.showKey?.isEmpty ?? true;
+      
+      if (needShowKey) {
+        // fetchAndParserImageInfo() then ehPrecacheImages()
+        // make sure showKey is parsed before ehPrecacheImages()
+        image = await _galleryPageController?.fetchAndParserImageInfo(
+        itemSer,
+        cancelToken: vState.getMoreCancelToken,
+        changeSource: changeSource,
+        );
+      }
+
       GalleryPara.instance
           .ehPrecacheImages(
         imageMap: _galleryPageStat?.imageMap,
@@ -582,11 +595,16 @@ class ViewExtController extends GetxController {
         }
       });
 
-      image = await _galleryPageController?.fetchAndParserImageInfo(
+      if (!needShowKey) {
+        // ehPrecacheImages() then fetchAndParserImageInfo()
+        // the original logic
+        image = await _galleryPageController?.fetchAndParserImageInfo(
         itemSer,
         cancelToken: vState.getMoreCancelToken,
         changeSource: changeSource,
-      );
+        );
+      }
+
     }
 
     return image;


### PR DESCRIPTION
The second image is requested to be precached before the first image is loaded. However, the showKey is not loaded until the first image infomation is fetched, so the second image cannot be precached properly.

The behavior is described in https://github.com/3003h/FEhViewer/pull/306#issue-2010720094
> (Only ser 2 is not cached)